### PR TITLE
Fix: improve clarity

### DIFF
--- a/docs/content/en/guide/setup.md
+++ b/docs/content/en/guide/setup.md
@@ -7,7 +7,7 @@ category: Guide
 
 ## Installation
 
-Add `@nuxtjs/mdx` as a dependency to your project:
+Add `@nuxtjs/mdx` as a development dependency to your project:
 
 <code-group>
   <code-block label="Yarn" active>


### PR DESCRIPTION
I believe specifying that the module is a development dependency is more clearer.