### PR TITLE
Exchange /setup with /guide/setup link

### DIFF
--- a/docs/content/en/guide/usage.md
+++ b/docs/content/en/guide/usage.md
@@ -34,7 +34,7 @@ Inside `hello.mdx`, add some markdown content:
   This a Nuxt MDX tomato.
 </section>
 
-<nuxt-link to="/setup">
+<nuxt-link to="/guide/setup">
   back to setup page &rarr;
 </nuxt-link>
 ```


### PR DESCRIPTION
## Description

Just a small change in the example moving from /setup (blank site) to /guide/setup (actual docs for installation)

## Motivation and Context

Update on documentation as I've clicked on the link and did expect the installation part rather than a blank site.

## How Has This Been Tested?

No changes in code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation Updated

